### PR TITLE
Update blast.sh, to avoid potential bugs during running

### DIFF
--- a/blast.sh
+++ b/blast.sh
@@ -1,2 +1,1 @@
 /cygdrive/c/BibPro/blast-2.2.18/bin/blastall -p blastp -d c:\\BibPro\\TemplateDB\\$2 -M BLOSUM80 -F F -W 1 -i c:\\BibPro\\$1.txt -o c:\\BibPro\\$1.out
-   


### PR DESCRIPTION
The trailing spaces on the second line of blash.sh will cause problem on some version of bash of cygwin, but it will not cause problem to zsh/